### PR TITLE
starred -> star?

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -108,17 +108,17 @@ Specification
 =============
 
 In the grammar, the rules for comprehensions and generator expressions
-would use ``starred_named_expression`` instead of ``named_expression``,
+would use ``star_named_expression`` instead of ``named_expression``,
 and ``double_starred_kvpair`` instead of ``kvpair``::
 
     listcomp:
-        | '[' starred_named_expression for_if_clauses ']' 
+        | '[' star_named_expression for_if_clauses ']'
     setcomp:
-        | '{' starred_named_expression for_if_clauses '}' 
+        | '{' star_named_expression for_if_clauses '}'
     dictcomp:
-        | '{' double_starred_kvpair for_if_clauses '}' 
+        | '{' double_starred_kvpair for_if_clauses '}'
     genexp:
-        | '(' starred_named_expression for_if_clauses ')' 
+        | '(' star_named_expression for_if_clauses ')'
 
 (Small note: the current rule for ``genexp`` uses
 ``( assigment_expression | expression !':=')`` but this is equivalent to


### PR DESCRIPTION
just poking around at the parser now, looks like this is called `star_named_expression` instead of `starred_named_expression`, unless i'm mistaken?